### PR TITLE
Collapse matrix data to keep only unique references to matrix cells.

### DIFF
--- a/presamples/campaigns.py
+++ b/presamples/campaigns.py
@@ -264,7 +264,7 @@ class Campaign(ModelBase):
         # Recursive queries not supported in peewee
         # Note that quoting is SQLite specific (Postgres uses %s)
         if not self.parent_id:
-            raise StopIteration
+            return
         for obj_id in Campaign.raw('''
             WITH RECURSIVE ancestors (level, id) AS (
                 VALUES(0, ?)

--- a/presamples/packaging.py
+++ b/presamples/packaging.py
@@ -557,6 +557,7 @@ def collapse_matrix_indices(samples, indices, kind):
             type, and technosphere amount samples are subtracted from production
             amount samples
         Other mix: Unexpected, will throw ValueError
+    Todo: substitution should also be taken care of
     """
     # Smaller array with just input and output fields, to identify repeated elements
     io_cols = indices[['input', 'output']]

--- a/presamples/packaging.py
+++ b/presamples/packaging.py
@@ -576,23 +576,6 @@ def collapse_matrix_indices(samples, indices, kind):
     # Create new indices and arrays for unique indices rows
     # Note that rows in sample associated with repeated indices will need to be replaced
     new_indices = copy.deepcopy(indices[unique_indices])
-    """
-    print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
-    print(new_indices.dtype, indices.dtype)
-    print(new_indices.shape, indices.shape)
-    print(indices)
-    print(new_indices)
-    print(indices[0].dtype)
-    print(indices[0]['row'])
-    print(indices[0]['input'])
-    print(indices[0]['type'])
-    print(new_indices[0].dtype)
-    print(new_indices[0]['row'])
-    print(new_indices[0]['input'])
-    print(new_indices[0]['type'])
-    print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
-    1/0
-    """
     new_samples = copy.deepcopy(samples[unique_indices, :])
     # For all indices that are not unique in the original indices array, get sum
     # of sample and insert it in the new_samples array
@@ -627,9 +610,5 @@ def collapse_matrix_indices(samples, indices, kind):
                 new_indices[repeated_index]['type'] = 0
         # Then, add samples for repeated indices and place in correct location
         # in samples array
-        print("%%%%%%%%%%%%%%%%%%%%")
-        print(new_samples.shape)
         new_samples[repeated_index, :] = np.sum(to_sum, axis=0)
-        print("%%%%%%%%%%%%%%%%%%%%")
-        print(new_samples.shape)
     return new_samples, new_indices

--- a/presamples/packaging.py
+++ b/presamples/packaging.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import uuid
 import copy
+import warnings
 
 from .errors import InconsistentSampleNumber, ShapeMismatch, NameConflicts
 from .utils import validate_presamples_dirpath, md5
@@ -236,7 +237,7 @@ def get_presample_directory(id_, overwrite=False, dirpath=None):
 
 
 def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
-        id_=None, overwrite=False, dirpath=None, seed=None):
+        id_=None, overwrite=False, dirpath=None, seed=None, collapse_repeated_indices=True):
     """Create and populate a new presamples package
 
      The presamples package minimally contains a datapackage file with metadata on the
@@ -259,6 +260,9 @@ def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
             An optional directory path where presamples can be created. If None, a subdirectory in the ``project`` folder.
         seed: {None, int, "sequential"}, optional
             Seed used by indexer to return array columns in random order. Can be an integer, "sequential" or None.
+        collapse_repeated_indices: bool, default=True
+            Indicates whether samples for the same matrix cell in a given array should be summed.
+            If False then only the last sample values are used.
 
     Notes
     ----
@@ -322,7 +326,16 @@ def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
 
         indices, metadata = format_matrix_data(indices, kind, *other)
         if kind in ['technosphere', 'biosphere']:
-            samples, indices = collapse_matrix_indices(samples, indices, kind)
+            if collapse_repeated_indices: # Avoid cf matrices for now
+                samples, indices = collapse_matrix_indices(samples, indices, kind)
+            else:
+                io_cols = indices[['input', 'output']]
+                unique = np.unique(io_cols)
+                if len(unique) != samples.shape[0]:
+                    warnings.warn(UserWarning('Multiple samples in a given array were supplied '
+                                  'for the same {} matrix cell, but collapse_repeated_indices '
+                                  'was set to False. Only the last sample values '
+                                  'will be considered.'.format(kind)))
 
         if samples.shape[0] != indices.shape[0]:
             error = "Shape mismatch between samples and indices: {}, {}, {}"
@@ -379,12 +392,14 @@ def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
     return id_, dirpath
 
 
-def append_presamples_package(dirpath, matrix_data=None, parameter_data=None):
+def append_presamples_package(dirpath, matrix_data=None, parameter_data=None, collapse_repeated_indices=True):
     """Append new sections to a presamples package.
 
     ``dirpath`` is the directory where the existing presamples can be found.
 
     ``matrix_data`` is a list of :ref:`matrix-presamples`; parameter_data`` is a list of :ref:`parameter-presamples`. Both are allowed, but at least one type of presamples must be given. The documentation gives more details on these input arguments.
+
+    ``collapse_repeated_indices`` is a boolean indicating whether samples for the same matrix cell in a given array should be summed. The default is True, if False then only the last sample values are used.
 
     Both matrix and parameter data should have the same number of possible values (i.e same number of samples).
 
@@ -424,6 +439,18 @@ def append_presamples_package(dirpath, matrix_data=None, parameter_data=None):
                 "{} and {}".format(samples.shape[1], num_iterations))
 
         indices, metadata = format_matrix_data(indices, kind, *other)
+        if kind in ['technosphere', 'biosphere']:
+            if collapse_repeated_indices: # Avoid cf matrices for now
+                samples, indices = collapse_matrix_indices(samples, indices, kind)
+            else:
+                io_cols = indices[['input', 'output']]
+                unique = np.unique(io_cols)
+                if len(unique) != samples.shape[0]:
+                    warnings.warn(UserWarning('Multiple samples in a given array were supplied '
+                                  'for the same {} matrix cell, but collapse_repeated_indices '
+                                  'was set to False. Only the last sample values '
+                                  'will be considered.'.format(kind)))
+
 
         if samples.shape[0] != indices.shape[0]:
             error = "Shape mismatch between samples and indices: {}, {}, {}"
@@ -572,7 +599,7 @@ def collapse_matrix_indices(samples, indices, kind):
     unique, unique_indices, inverse, count = np.unique(
         io_cols, return_index=True, return_inverse=True, return_counts=True
     )
-    if len(unique) == samples.shape[0]: # No repeated indices, nothing to do
+    if len(unique) == io_cols.shape[0]: # No repeated indices, nothing to do
         return samples, indices
     # Create new indices and arrays for unique indices rows
     # Note that rows in sample associated with repeated indices will need to be replaced
@@ -586,29 +613,38 @@ def collapse_matrix_indices(samples, indices, kind):
         r_indices_in_original_data = np.argwhere(inverse == repeated_index).ravel()
         to_sum = samples[r_indices_in_original_data]
         # If the matrix kind is technosphere, we cannot simply sum because
-        # we might be in the presence of a case where there are both production
-        # (type==0) and technosphere (type==1) exchanges.
-        # If this is the case, we will subtract the technosphere
-        # exchange amount samples from the production exchange amount samples,
-        # and store the data with production type
+        # we might be in the presence of a case where there are different types of
+        # exchanges. Currently, these can be production(type==0),
+        # technosphere (type==1) or substitution (type==3) exchanges.
+        # Production and substitution exchanges are outputs, while
+        # technosphere are inputs.
+        # How we consolidate samples depends on the types present
         if kind == 'technosphere':
             types = indices[r_indices_in_original_data]['type']
             unique_types = np.unique(types)
             # If all the same type, we can simply add, so pass for now
             if len(unique_types) == 1:
                 pass
-            # If not all the same type, but types not production and technosphere,
-            # then we are in an unanticipated situation. Throw a ValueError.
-            elif list(unique_types) != [0, 1]:
-                raise ValueError("Repeated index {} has types {}, which has us baffled".format(
-                    repeated_index, list(unique_types)
-                ))
-            # Else, technosphere and production exchanges in presamples.
-            # Keep production and subtract technosphere
-            else:
+            # If we have production and technosphere exchanges,
+            # we will subtract the technosphere exchange amount samples
+            # from the production or substitution exchange amount samples,
+            # and store the data with production type
+            elif list(unique_types) == [0, 1]:
                 sign_mod = np.array([1 if t == 0 else -1 for t in types]).reshape(-1, 1)
                 to_sum = to_sum * sign_mod
                 new_indices[repeated_index]['type'] = 0
+            # If we have substitution and technosphere exchanges,
+            # we will subtract the technosphere exchange amount samples
+            # from the substitution exchange amount samples,
+            # and store the data with substitution type
+            elif list(unique_types) == [1, 3]:
+                sign_mod = np.array([1 if t == 3 else -1 for t in types]).reshape(-1, 1)
+                to_sum = to_sum * sign_mod
+                new_indices[repeated_index]['type'] = 3
+            else:
+                raise ValueError("Repeated index {} has types {}, which has us baffled".format(
+                    repeated_index, list(unique_types)
+                ))
         # Then, add samples for repeated indices and place in correct location
         # in samples array
         new_samples[repeated_index, :] = np.sum(to_sum, axis=0)

--- a/presamples/packaging.py
+++ b/presamples/packaging.py
@@ -321,7 +321,8 @@ def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
                 "{} and {}".format(samples.shape[1], num_iterations))
 
         indices, metadata = format_matrix_data(indices, kind, *other)
-        samples, indices = collapse_matrix_indices(samples, indices, kind)
+        if kind in ['technosphere', 'biosphere']:
+            samples, indices = collapse_matrix_indices(samples, indices, kind)
 
         if samples.shape[0] != indices.shape[0]:
             error = "Shape mismatch between samples and indices: {}, {}, {}"

--- a/presamples/packaging.py
+++ b/presamples/packaging.py
@@ -334,8 +334,8 @@ def create_presamples_package(matrix_data=None, parameter_data=None, name=None,
                 if len(unique) != samples.shape[0]:
                     warnings.warn(UserWarning('Multiple samples in a given array were supplied '
                                   'for the same {} matrix cell, but collapse_repeated_indices '
-                                  'was set to False. Only the last sample values '
-                                  'will be considered.'.format(kind)))
+                                  'was set to False. All samples will be stored, but only '
+                                  'the last sample values will be used.'.format(kind)))
 
         if samples.shape[0] != indices.shape[0]:
             error = "Shape mismatch between samples and indices: {}, {}, {}"
@@ -448,8 +448,8 @@ def append_presamples_package(dirpath, matrix_data=None, parameter_data=None, co
                 if len(unique) != samples.shape[0]:
                     warnings.warn(UserWarning('Multiple samples in a given array were supplied '
                                   'for the same {} matrix cell, but collapse_repeated_indices '
-                                  'was set to False. Only the last sample values '
-                                  'will be considered.'.format(kind)))
+                                  'was set to False. All samples will be stored, but only '
+                                  'the last sample values will be used.'.format(kind)))
 
 
         if samples.shape[0] != indices.shape[0]:

--- a/tests/campaigns.py
+++ b/tests/campaigns.py
@@ -89,6 +89,14 @@ def test_campaign_modified_autopopulate_autoupdate():
     assert dt < c.modified
 
 @bw2test
+def test_campaign_ancestors_no_error():
+    c1 = Campaign.create(name='a')
+    c2 = Campaign.create(name='b', parent=c1)
+
+    assert [_ for _ in c1.ancestors] == []
+    assert list(c1.ancestors) == []
+
+@bw2test
 def test_campaign_lineage():
     c1 = Campaign.create(name='a')
     c2 = Campaign.create(name='b', parent=c1)

--- a/tests/loader.py
+++ b/tests/loader.py
@@ -212,9 +212,10 @@ def test_update_matrices_technosphere_no_consolidation():
         ('C', 'D', 1)
         ]
     t2 = np.arange(5).reshape((5, 1)) + 10
-    expected_warning = 'Multiple samples in a given array were supplied for the' \
-                       ' same technosphere matrix cell, but collapse_repeated_indices' \
-                       ' was set to False. Only the last sample values will be considered.'
+
+    expected_warning = 'Multiple samples in a given array were supplied for the same technosphere ' \
+                       'matrix cell, but collapse_repeated_indices was set to False.' \
+                       ' All samples will be stored, but only the last sample values will be used.'
     with pytest.warns(UserWarning, match=expected_warning):
         _, dirpath = create_presamples_package([(t2, t1, 'technosphere')],
                                               collapse_repeated_indices=False)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -217,6 +217,127 @@ def test_basic_packaging():
     create_presamples_package(parameter_data=[(s1, n1, '1'), (s2, n2, '2')])
 
 @bw2test
+def test_packaging_repeated_indices():
+    mapping.add('ABCDEF')
+    t1 = [
+        ('A', 'A', 1),
+        ('A', 'A', 0),
+        ('A', 'B', 1),
+        ('A', 'B', 1),
+        ('A', 'C', 1),
+        ('B', 'B', 0),
+        ('B', 'C', 1),
+    ]
+    t2 = np.arange(28, dtype=np.int64).reshape((7, 4))
+    b1 = [('A', 'D'), ('A', 'D'), ('B', 'E')]
+    b2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    inputs = [
+        (t2, t1, 'technosphere'),
+        (b2, b1, 'biosphere'),
+    ]
+    id_, dirpath = create_presamples_package(
+        inputs, name='foo', id_='bar', seed=42
+    )
+    assert id_ == 'bar'
+    dirpath = Path(dirpath)
+    expected = sorted([
+        'bar.0.indices.npy', 'bar.0.samples.npy',
+        'bar.1.indices.npy', 'bar.1.samples.npy',
+        'datapackage.json'
+    ])
+    assert sorted(os.listdir(dirpath)) == expected
+    expected = sorted([
+        (1, 1, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (1, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+    ])
+    assert np.load(dirpath / 'bar.0.indices.npy').tolist() == expected
+    expected = np.array(
+        [
+            [4, 4, 4, 4],
+            [20, 22, 24, 26],
+            [16, 17, 18, 19],
+            [20, 21, 22, 23],
+            [24, 25, 26, 27]
+        ], dtype=np.int64)
+
+    assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)
+    expected = ([
+        (1, 4, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+        (2, 5, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+    ])
+    assert np.load(dirpath / 'bar.1.indices.npy').tolist() == expected
+    expected = np.array(
+        [
+            [4, 6, 8, 10],
+            [8, 9, 10, 11],
+        ], dtype=np.int64)
+    assert np.allclose(np.load(dirpath / 'bar.1.samples.npy'), expected)
+    expected = {
+        'id': 'bar',
+        'name': 'foo',
+        'profile': 'data-package',
+        'seed': 42,
+        'ncols': 4,
+        'resources': [{
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.0.samples.npy',
+                'md5': None,
+                'shape': [5, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.0.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 0,
+            'matrix': 'technosphere_matrix',
+            'row dict': '_product_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'technosphere'
+        }, {
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.1.samples.npy',
+                'md5': None,
+                'shape': [2, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.1.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 1,
+            'matrix': 'biosphere_matrix',
+            'row dict': '_biosphere_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'biosphere'
+        }
+    ]}
+    given = json.load(open(dirpath / 'datapackage.json'))
+    update_hashes_from_given(given, expected)
+    assert given == expected
+
+@bw2test
 def test_basic_packaging_custom_directory():
     mapping.add('ABCDEF')
     t1 = [('A', 'A', 0), ('A', 'B', 1), ('B', 'C', 3)]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -227,8 +227,9 @@ def test_packaging_repeated_indices():
         ('A', 'C', 1),
         ('B', 'B', 0),
         ('B', 'C', 1),
+        ('B', 'C', 3),
     ]
-    t2 = np.arange(28, dtype=np.int64).reshape((7, 4))
+    t2 = np.arange(32, dtype=np.int64).reshape((8, 4))
     b1 = [('A', 'D'), ('A', 'D'), ('B', 'E')]
     b2 = np.arange(12, dtype=np.int64).reshape((3, 4))
     inputs = [
@@ -251,7 +252,7 @@ def test_packaging_repeated_indices():
         (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
         (1, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
         (2, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
-        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 3),
     ])
     assert np.load(dirpath / 'bar.0.indices.npy').tolist() == expected
     expected = np.array(
@@ -260,7 +261,7 @@ def test_packaging_repeated_indices():
             [20, 22, 24, 26],
             [16, 17, 18, 19],
             [20, 21, 22, 23],
-            [24, 25, 26, 27]
+            [4, 4, 4, 4]
         ], dtype=np.int64)
 
     assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -808,6 +808,395 @@ def test_basic_package_appending():
     assert given == expected
 
 @bw2test
+def test_basic_package_appending_repeated_indices():
+    mapping.add('ABCDEF')
+    t1 = [('A', 'A', 0), ('A', 'B', 1), ('B', 'C', 3)]
+    t2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    inputs = [
+        (t2, t1, 'technosphere'),
+    ]
+    id_, dirpath = create_presamples_package(
+        inputs, name='foo', id_='bar', seed=216
+    )
+    assert id_ == 'bar'
+    dirpath = Path(dirpath)
+    expected = sorted([
+        'bar.0.indices.npy', 'bar.0.samples.npy',
+        'datapackage.json'
+    ])
+    assert sorted(os.listdir(dirpath)) == expected
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)
+    expected = [
+        (1, 1, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 3),
+    ]
+    assert np.load(dirpath / 'bar.0.indices.npy').tolist() ==  expected
+    expected = {
+        'id': 'bar',
+        'name': 'foo',
+        'profile': 'data-package',
+        'seed': 216,
+        'ncols': 4,
+        'resources': [{
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.0.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.0.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 0,
+            'matrix': 'technosphere_matrix',
+            'row dict': '_product_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'technosphere'
+        }
+    ]}
+    given = json.load(open(dirpath / 'datapackage.json'))
+    update_hashes_from_given(given, expected)
+    assert given == expected
+
+    b1 = [('A', 'D'), ('A', 'D'), ('B', 'F')]
+    b2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    c1 = 'DEF'
+    c2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    inputs = [
+        (b2, b1, 'biosphere'),
+        (c2, c1, 'cf'),
+    ]
+    a, b = append_presamples_package(
+        dirpath=dirpath,
+        matrix_data=inputs,
+    )
+    assert a == id_
+    assert b == dirpath
+    expected = sorted([
+        'bar.0.indices.npy', 'bar.0.samples.npy',
+        'bar.1.indices.npy', 'bar.1.samples.npy',
+        'bar.2.indices.npy', 'bar.2.samples.npy',
+        'datapackage.json'
+    ])
+    assert sorted(os.listdir(dirpath)) == expected
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.2.samples.npy'), expected)
+    expected = np.array([4,6,8,10,8,9,10,11], dtype=np.int64).reshape((2, 4))
+    assert np.allclose(np.load(dirpath / 'bar.1.samples.npy'), expected)
+    expected = [
+        (1, 1, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 3),
+    ]
+    assert np.load(dirpath / 'bar.0.indices.npy').tolist() ==  expected
+    expected = [
+        (1, 4, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+        (2, 6, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+    ]
+    assert np.load(dirpath / 'bar.1.indices.npy').tolist() ==  expected
+    expected = [
+        (4, MAX_SIGNED_32BIT_INT),
+        (5, MAX_SIGNED_32BIT_INT),
+        (6, MAX_SIGNED_32BIT_INT),
+    ]
+    assert np.load(dirpath / 'bar.2.indices.npy').tolist() ==  expected
+    expected = {
+        'id': 'bar',
+        'name': 'foo',
+        'profile': 'data-package',
+        'seed': 216,
+        'ncols': 4,
+        'resources': [{
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.0.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.0.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 0,
+            'matrix': 'technosphere_matrix',
+            'row dict': '_product_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'technosphere'
+        }, {
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.1.samples.npy',
+                'md5': None,
+                'shape': [2, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.1.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 1,
+            'matrix': 'biosphere_matrix',
+            'row dict': '_biosphere_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'biosphere'
+        }, {
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.2.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.2.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 2,
+            'matrix': 'characterization_matrix',
+            'row dict': '_biosphere_dict',
+            'row from label': 'flow',
+            'row to label': 'row',
+            'type': 'cf'
+        }
+    ]}
+    given = json.load(open(dirpath / 'datapackage.json'))
+    update_hashes_from_given(given, expected)
+    assert given == expected
+
+
+@bw2test
+def test_basic_package_appending_repeated_indices_no_consolidate():
+    mapping.add('ABCDEF')
+    t1 = [('A', 'A', 0), ('A', 'B', 1), ('B', 'C', 3)]
+    t2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    inputs = [
+        (t2, t1, 'technosphere'),
+    ]
+    id_, dirpath = create_presamples_package(
+        inputs, name='foo', id_='bar', seed=216
+    )
+    assert id_ == 'bar'
+    dirpath = Path(dirpath)
+    expected = sorted([
+        'bar.0.indices.npy', 'bar.0.samples.npy',
+        'datapackage.json'
+    ])
+    assert sorted(os.listdir(dirpath)) == expected
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)
+    expected = [
+        (1, 1, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 3),
+    ]
+    assert np.load(dirpath / 'bar.0.indices.npy').tolist() ==  expected
+    expected = {
+        'id': 'bar',
+        'name': 'foo',
+        'profile': 'data-package',
+        'seed': 216,
+        'ncols': 4,
+        'resources': [{
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.0.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.0.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 0,
+            'matrix': 'technosphere_matrix',
+            'row dict': '_product_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'technosphere'
+        }
+    ]}
+    given = json.load(open(dirpath / 'datapackage.json'))
+    update_hashes_from_given(given, expected)
+    assert given == expected
+
+    b1 = [('A', 'D'), ('A', 'D'), ('B', 'F')]
+    b2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    c1 = 'DEF'
+    c2 = np.arange(12, dtype=np.int64).reshape((3, 4))
+    inputs = [
+        (b2, b1, 'biosphere'),
+        (c2, c1, 'cf'),
+    ]
+
+    expected_warning = 'Multiple samples in a given array were supplied for the same biosphere ' \
+                       'matrix cell, but collapse_repeated_indices was set to False.' \
+                       ' All samples will be stored, but only the last sample values will be used.'
+    with pytest.warns(UserWarning, match=expected_warning):
+        a, b = append_presamples_package(
+            dirpath=dirpath,
+            matrix_data=inputs,
+            collapse_repeated_indices=False
+        )
+    assert a == id_
+    assert b == dirpath
+    expected = sorted([
+        'bar.0.indices.npy', 'bar.0.samples.npy',
+        'bar.1.indices.npy', 'bar.1.samples.npy',
+        'bar.2.indices.npy', 'bar.2.samples.npy',
+        'datapackage.json'
+    ])
+    assert sorted(os.listdir(dirpath)) == expected
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.0.samples.npy'), expected)
+    expected = np.arange(12, dtype=np.int64).reshape((3, 4))
+    assert np.allclose(np.load(dirpath / 'bar.2.samples.npy'), expected)
+    assert np.allclose(np.load(dirpath / 'bar.1.samples.npy'), expected)
+    expected = [
+        (1, 1, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 0),
+        (1, 2, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 1),
+        (2, 3, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT, 3),
+    ]
+    assert np.load(dirpath / 'bar.0.indices.npy').tolist() ==  expected
+    expected = [
+        (1, 4, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+        (1, 4, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+        (2, 6, MAX_SIGNED_32BIT_INT, MAX_SIGNED_32BIT_INT),
+    ]
+    assert np.load(dirpath / 'bar.1.indices.npy').tolist() ==  expected
+    expected = [
+        (4, MAX_SIGNED_32BIT_INT),
+        (5, MAX_SIGNED_32BIT_INT),
+        (6, MAX_SIGNED_32BIT_INT),
+    ]
+    assert np.load(dirpath / 'bar.2.indices.npy').tolist() ==  expected
+    expected = {
+        'id': 'bar',
+        'name': 'foo',
+        'profile': 'data-package',
+        'seed': 216,
+        'ncols': 4,
+        'resources': [{
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.0.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.0.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 0,
+            'matrix': 'technosphere_matrix',
+            'row dict': '_product_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'technosphere'
+        }, {
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.1.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.1.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 1,
+            'matrix': 'biosphere_matrix',
+            'row dict': '_biosphere_dict',
+            'row from label': 'input',
+            'row to label': 'row',
+            'col dict': '_activity_dict',
+            'col from label': 'output',
+            'col to label': 'col',
+            'type': 'biosphere'
+        }, {
+            'profile': 'data-resource',
+            'samples': {
+                'dtype': 'int64',
+                'filepath': 'bar.2.samples.npy',
+                'md5': None,
+                'shape': [3, 4],
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'indices': {
+                'filepath': 'bar.2.indices.npy',
+                'md5': None,
+                'format': 'npy',
+                'mediatype': 'application/octet-stream',
+            },
+            'index': 2,
+            'matrix': 'characterization_matrix',
+            'row dict': '_biosphere_dict',
+            'row from label': 'flow',
+            'row to label': 'row',
+            'type': 'cf'
+        }
+    ]}
+    given = json.load(open(dirpath / 'datapackage.json'))
+    update_hashes_from_given(given, expected)
+    assert given == expected
+
+@bw2test
 def test_package_appending_matrix():
     mapping.add('ABCDEF')
     s1 = np.arange(16, dtype=np.int64).reshape((4, 4))


### PR DESCRIPTION
Sums samples for given matrix cells. If there are mixed types (technosphere and production, which occurs when there is a loss), technosphere samples are subtracted from production samples and the indices assumes a production exchange.
This is only done for individual matrix_data (sample, indices, kind) tuples.

Note: the failing test also fails for master, as discussed [here](https://github.com/PascalLesage/presamples/issues/61)