### PR TITLE
Drop raising stopiteration.

### DIFF
--- a/presamples/campaigns.py
+++ b/presamples/campaigns.py
@@ -264,7 +264,7 @@ class Campaign(ModelBase):
         # Recursive queries not supported in peewee
         # Note that quoting is SQLite specific (Postgres uses %s)
         if not self.parent_id:
-            raise StopIteration
+            return
         for obj_id in Campaign.raw('''
             WITH RECURSIVE ancestors (level, id) AS (
                 VALUES(0, ?)

--- a/tests/campaigns.py
+++ b/tests/campaigns.py
@@ -89,6 +89,14 @@ def test_campaign_modified_autopopulate_autoupdate():
     assert dt < c.modified
 
 @bw2test
+def test_campaign_ancestors_no_error():
+    c1 = Campaign.create(name='a')
+    c2 = Campaign.create(name='b', parent=c1)
+
+    assert [_ for _ in c1.ancestors] == []
+    assert list(c1.ancestors) == []
+
+@bw2test
 def test_campaign_lineage():
     c1 = Campaign.create(name='a')
     c2 = Campaign.create(name='b', parent=c1)


### PR DESCRIPTION
Could solve #61. As [PEP 479](https://www.python.org/dev/peps/pep-0479/) is accepted, this is the correct behaviour.