### PR TITLE
filter non-defined elementary flows

### DIFF
--- a/presamples/loader.py
+++ b/presamples/loader.py
@@ -275,10 +275,13 @@ class PackagesDataLoader:
                         elem['indices'][elem['col to label']],
                     ] = sample
                 else:
+                    # filter elementary flows not in database
+                    mask = np.isin(elem['indices'][elem['row to label']],matrix.indices)
+                    existing = elem['indices'][elem['row to label']][mask]
                     matrix[
-                        elem['indices'][elem['row to label']],
-                        elem['indices'][elem['row to label']],
-                    ] = sample
+                        existing,
+                        existing,
+                    ] = sample[mask]
 
     def update_package_indices(self):
         """Move to next index"""


### PR DESCRIPTION
Hi!

This is a pull request related to the issue identified [here](https://stackoverflow.com/questions/62378752/index-error-on-presamples-of-characterisation-factors) where the calculation crashes if we use samples of characterisation factors of elementary flows that are not present in the database. 

I think this would fix the problem, I hope it does not break anything. It would be cool to have in the readme some instructions about how to run the tests  :) 