### PR TITLE
Issue 72

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 0.2.8 (2021-03-09)
+
+Fix #72 to allow python 3.9 to parse json files
+
 # 0.2.7 (2020-02-11)
 
 Utility function to change the path of a presample resource

--- a/presamples/loader.py
+++ b/presamples/loader.py
@@ -130,8 +130,7 @@ class PackagesDataLoader:
             Dictionary with loaded data
         """
         metadata = json.load(
-            open(dirpath / "datapackage.json"),
-            encoding="utf-8"
+            open(dirpath / "datapackage.json")
         )
         get_seed = lambda x: seed if seed is not None else x
         data = {

--- a/presamples/utils.py
+++ b/presamples/utils.py
@@ -41,8 +41,7 @@ def validate_presamples_dirpath(path):
     files = list(os.listdir(path))
     assert "datapackage.json" in files, "{} missing a datapackage file".format(path)
     metadata = json.load(
-        open(path / "datapackage.json"),
-        encoding="utf-8"
+        open(path / "datapackage.json")
     )
     for resource in metadata['resources']:
         assert os.path.isfile(path / resource['samples']['filepath'])

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def package_files(directory):
 
 setup(
     name='presamples',
-    version="0.2.7",
+    version="0.2.8",
     packages=packages,
     author="Pascal Lesage",
     author_email="pascal.lesage@polymtl.ca",
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'Topic :: Scientific/Engineering :: Mathematics',
     ],

--- a/tests/campaigns.py
+++ b/tests/campaigns.py
@@ -342,7 +342,13 @@ def test_campaign_add_local_presamples_copy(tempdir_package):
     assert len(c) == 1
     pr1 = PresampleResource.get()
     assert Path(pr1.path) != tempdir_package
-    assert os.listdir(pr1.path) == os.listdir(tempdir_package)
+    # os.listdir yields names of the entries in the directory in arbitrary order
+    # https://docs.python.org/3/library/os.html#os.listdir
+    # we could test element-wise
+    # with the "misleadingly-named" assertCountEqual
+    # https://docs.python.org/3/library/unittest.html?highlight=assertcountequal#unittest.TestCase.assertCountEqual
+    # but for a simpler solution, we test-compare sets
+    assert set(os.listdir(pr1.path)) == set(os.listdir(tempdir_package))
     PresamplesPackage(pr1.path)
     PresamplesPackage(tempdir_package)
 


### PR DESCRIPTION
In python 3.9.2 the encoding keyword argument in `json.loads` has been removed (it was deprecated since 3.1).
This patch does 2 things:

+ removes the use of the keyword argument
+ updates an assertion statement in a test that was failing. The failure was because of an assertion comparing unsorted lists of entries coming from `os.listdir`

I updated the test so that the PR Is "test" compliant ;)

I tested the branch code with both 3.8 and 3.9. Maybe presamples is ready to officially support "3.9" (add the classifiers to the setup tools)