### PR TITLE
Add conda-forge package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
  
  Presamples are useful anytime values for named parameters or matrix elements need to be saved and reused.
  
- **Installation**: Via `pip` or `conda` (`conda install --channel pascallesage presamples`).
+ **Installation**: Via `pip` or `conda` (`conda install -c conda-forge presamples`).
  
  **Documentation**: We are in the process of writing better documentation.  
  - To read our documentation "under construction", go to our [readthedocs](https://presamples.readthedocs.io/en/latest/?badge=latest) page. 
  - If you can't find what you are looking for, you can also try the Jupyter Notebook [here](https://github.com/PascalLesage/presamples/tree/master/docs/notebooks/presamples%20docs%20and%20examples.ipynb)
  
-
+[![PyPi Version](https://img.shields.io/pypi/v/presamples.svg)](https://pypi.org/project/presamples/)
+[![Conda Version](https://img.shields.io/conda/vn/conda-forge/presamples.svg)](https://anaconda.org/conda-forge/presamples)
 [![Linux/OS X build status](https://travis-ci.org/PascalLesage/presamples.svg?branch=master)](https://travis-ci.org/PascalLesage/presamples) 
 [![Windows build status](https://ci.appveyor.com/api/projects/status/pb519kt7kbs188oi/branch/master?svg=true)](https://ci.appveyor.com/project/PascalLesage/presamples/branch/master)
 [![Coverage Status](https://coveralls.io/repos/github/PascalLesage/presamples/badge.svg?branch=master)](https://coveralls.io/github/PascalLesage/presamples?branch=master)


### PR DESCRIPTION
People at our company want to use packages of the [brightway ecosystem](https://github.com/brightway-lca) and [activity-browser](https://github.com/LCA-ActivityBrowser/activity-browser). As we rely heavily on conda-forge I bring all packages we use at our company there and maintain a few feedstocks. I already added your package to [conda-forge](https://conda-forge.org/). If you wish I can also add you as a feedstock maintainer. Otherwise I will happily maintain the recipe.